### PR TITLE
Add svelte export condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,13 @@
     "dist",
     "types"
   ],
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "svelte": "./src/index.js",
+      "default": "./dist/svelte-tiny-virtual-list.js"
+    }
+  },
   "keywords": [
     "svelte",
     "virtual",


### PR DESCRIPTION
Adds an export condition to replace the deprecated "svelte" field. The "svelte" field will stop working at some point in the future with `vite-plugin-svelte`.

https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition