### PR TITLE
fix: prefer `item` snippet over deprecated `children` snippet in code

### DIFF
--- a/src/lib/VirtualList.svelte
+++ b/src/lib/VirtualList.svelte
@@ -345,7 +345,7 @@
 	<div class="virtual-list-inner" style={innerStyle}>
 		{#each items as item (getKey ? getKey(item.index) : item.index)}
 			{#if item.index < itemCount}
-				{@render (childrenSnippet || itemSnippet)({ style: item.style, index: item.index })}
+				{@render (itemSnippet || childrenSnippet)({ style: item.style, index: item.index })}
 			{/if}
 		{/each}
 	</div>


### PR DESCRIPTION
If both are defined for some reason, it should prefer the `item` snippet instead of the deprecated `children` snippet.